### PR TITLE
Make all jobs source config.resources.

### DIFF
--- a/jobs/JGFS_ATMOS_FBWIND
+++ b/jobs/JGFS_ATMOS_FBWIND
@@ -6,7 +6,7 @@
 # GFS FBWIND PRODUCT GENERATION
 ############################################
 source "${HOMEgfs}/ush/preamble.sh"
-source "${HOMEgfs}/ush/jjob_header.sh" -e "fbwind" -c "base"
+source "${HOMEgfs}/ush/jjob_header.sh" -e "fbwind" -c "base fbwind"
 
 ###################################
 # Specify NET and RUN Name and model

--- a/jobs/JGFS_ATMOS_GEMPAK_META
+++ b/jobs/JGFS_ATMOS_GEMPAK_META
@@ -6,7 +6,7 @@
 # GFS GEMPAK META PRODUCT GENERATION
 ############################################
 source "${HOMEgfs}/ush/preamble.sh"
-source "${HOMEgfs}/ush/jjob_header.sh" -e "gempak_meta" -c "base"
+source "${HOMEgfs}/ush/jjob_header.sh" -e "gempak_meta" -c "base gempak"
 
 
 ###############################################

--- a/jobs/JGFS_ATMOS_GEMPAK_PGRB2_SPEC
+++ b/jobs/JGFS_ATMOS_GEMPAK_PGRB2_SPEC
@@ -1,7 +1,7 @@
 #! /usr/bin/env bash
 
 source "${HOMEgfs}/ush/preamble.sh"
-source "${HOMEgfs}/ush/jjob_header.sh" -e "gempak_spec" -c "base"
+source "${HOMEgfs}/ush/jjob_header.sh" -e "gempak_spec" -c "base gempak"
 
 ############################################
 # Set up model and cycle specific variables

--- a/parm/config/gfs/config.fbwind
+++ b/parm/config/gfs/config.fbwind
@@ -6,6 +6,6 @@
 echo "BEGIN: config.fbwind"
 
 # Get task specific resources
-. $EXPDIR/config.resources fbwind
+source "${EXPDIR}/config.resources" fbwind
 
 echo "END: config.fbwind"

--- a/parm/config/gfs/config.fbwind
+++ b/parm/config/gfs/config.fbwind
@@ -1,0 +1,11 @@
+#! /usr/bin/env bash
+
+########## config.gempak ##########
+# GFS fbwind step specific
+
+echo "BEGIN: config.fbwind"
+
+# Get task specific resources
+. $EXPDIR/config.resources fbwind
+
+echo "END: config.fbwind"

--- a/parm/config/gfs/config.resources
+++ b/parm/config/gfs/config.resources
@@ -1124,6 +1124,13 @@ case ${step} in
     memory_gfs="2GB"
     ;;
 
+  "fbwind")
+    walltime="00:05:00"
+    ntasks=1
+    threads_per_task=1
+    memory="4GB"
+    ;;
+
   "mos_stn_prep")
     walltime="00:10:00"
     ntasks=3


### PR DESCRIPTION
This makes the two remaining `GEMPAK` J-Jobs that were not sourcing `config.resources` do so.  Additionally, it adds a config file for the `fbwind` J-Job and adds definitions for the job to `config.resources` based on the `ecf` definitions for the job.

I made these changes locally to the CI clone for PR 2753 on WCOSS2 and relaunched the previously failed GEMPAK jobs, which are now running successfully.  I will open this for review when the WCOSS2 extended test is finished.